### PR TITLE
Skip spotlessCheck during CI and wpilib builds

### DIFF
--- a/.github/workflows/frcbuild.yml
+++ b/.github/workflows/frcbuild.yml
@@ -31,4 +31,4 @@ jobs:
 
     # Runs a single command using the runners shell
     - name: Compile and run tests on robot code
-      run: ./gradlew build
+      run: ./gradlew build -x spotlessCheck

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,5 +26,6 @@
     },
   ],
   "java.test.defaultConfig": "WPIlibUnitTests",
-  "java.format.settings.url": "eclipse-java-google-style.xml"
+  "java.format.settings.url": "eclipse-java-google-style.xml",
+  "wpilib.additionalGradleArguments": "-x spotlessCheck"
 }


### PR DESCRIPTION
Wpilib builds refer to builds triggered using the WPILib: Build Robot Code command